### PR TITLE
[Fix] model-download-fail-due-to-whitespace-in-username

### DIFF
--- a/download_models.js
+++ b/download_models.js
@@ -43,7 +43,7 @@ async function download() {
         console.log(`\nCloning ${modelName} from ${modelUrl}...`);
         try {
             // Use --depth 1 for a shallow clone to save space and time
-            await execPromise(`git clone --depth 1 ${modelUrl} ${targetDir}`);
+            await execPromise(`git clone --depth 1 ${modelUrl} "${targetDir}"`);
             console.log(`Successfully cloned ${modelName}`);
         } catch (error) {
             console.error(`\nFailed to clone ${modelName}:`, error);


### PR DESCRIPTION
Previously, git clone failed if `targetDir` contained `whitespace` `(e.g., in the user’s PC username: Vaibhav Nayak)` because the path wasn’t quoted.

This PR wraps `targetDir` in quotes to ensure the command works with spaces in file paths.

No impact on existing functionality for paths without spaces.