### PR TITLE
Fixed repository link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ### One-Click Launch
 ```bash
 # Clone the project
-git clone https://github.com/GRISHM7890/Bella.git
+git clone https://github.com/Jackywine/Bella.git
 cd Bella
 
 # Install dependencies


### PR DESCRIPTION
The previous instructions pointed to the wrong repo link, which is several commits behind. The npm run download was failing, so corrected it.